### PR TITLE
feat: 개설한 챌린지 코드 수정해서 어드민 유무 판별하기 #4

### DIFF
--- a/controllers/myChallenge.js
+++ b/controllers/myChallenge.js
@@ -2,19 +2,37 @@ import express from "express";
 import { getMyChallenges } from "../services/myChallenge.js";
 
 export const myChallengesApply = async (req, res, next) => {
+  const userId = req.user.id;
+  const userIsAdmin = req.user.isAdmin;
+  console.log("userId---" + userId);
+  console.log("userIsAdmin---" + userIsAdmin);
+
   const { status, keyword } = req.query;
   const page = Number(req.query.page) || 1;
   const limit = Number(req.query.limit) || 10;
-  const testUserId = "2";
 
+  if (status) {
+    status = status.toUpperCase();
+  }
+
+  let result;
   try {
-    const result = await getMyChallenges({
-      userId: testUserId,
-      status,
-      keyword,
-      page: Number(page),
-      limit: Number(limit),
-    });
+    if (userIsAdmin) {
+      result = await getMyChallenges({
+        status,
+        keyword,
+        page: Number(page),
+        limit: Number(limit),
+      });
+    } else {
+      result = await getMyChallenges({
+        userId,
+        status,
+        keyword,
+        page: Number(page),
+        limit: Number(limit),
+      });
+    }
 
     res.json(result);
   } catch (error) {

--- a/repositories/myChallenge.js
+++ b/repositories/myChallenge.js
@@ -10,7 +10,7 @@ export const findMyChallenges = async ({
   limit,
 }) => {
   const where = {
-    userId: userId,
+    ...(userId && { userId }),
     ...(status && {
       ChallengeStatusManage: {
         is: {
@@ -41,7 +41,7 @@ export const findMyChallenges = async ({
 // 조건에 맞는 전체 개수 조회
 export const countMyChallenges = async ({ userId, status, keyword }) => {
   const where = {
-    userId: userId,
+    ...(userId && { userId }),
     ...(status && {
       ChallengeStatusManage: {
         is: {

--- a/routes/myChallenge.js
+++ b/routes/myChallenge.js
@@ -1,8 +1,13 @@
 import express from "express";
+import passport from "../config/passport.js";
 import { myChallengesApply } from "../controllers/myChallenge.js";
 
 const router = express.Router();
 
-router.get("/", myChallengesApply);
+router.get(
+  "/",
+  passport.authenticate("access-token", { session: false }),
+  myChallengesApply
+);
 
 export default router;

--- a/services/myChallenge.js
+++ b/services/myChallenge.js
@@ -14,7 +14,7 @@ export async function getMyChallenges({
 
   // 검색 및 필터 구성 요소
   const filters = {
-    userId,
+    userId: userId || null,
     status: status || null,
     keyword: keyword || null,
     offset,


### PR DESCRIPTION
이슈 번호 #4

요약 : 개설한 챌린지 api 액세스 토큰 인증 미들웨어 + 어드민 권한 유무 코드 추가

관련 작업 내역:
- [X] 어드민일때, 챌린지 목록 다 가져오기
- [X] 유저일때는 본인이 개설한 챌린지만 가져오기
- [ ] 어드민일때, 정렬 필터링 구현