### PR TITLE
feat:개설한 챌린지 + 어드민 챌린지 신청관리 공통 사용을 위해 정렬 쿼리 추가 #4

### DIFF
--- a/controllers/myChallenge.js
+++ b/controllers/myChallenge.js
@@ -1,17 +1,16 @@
-import express from "express";
 import { getMyChallenges } from "../services/myChallenge.js";
 
 export const myChallengesApply = async (req, res, next) => {
   const userId = req.user.id;
   const userIsAdmin = req.user.isAdmin;
-  console.log("userId---" + userId);
-  console.log("userIsAdmin---" + userIsAdmin);
 
-  const { status, keyword } = req.query;
+  let { status, keyword, orderBy } = req.query;
   const page = Number(req.query.page) || 1;
   const limit = Number(req.query.limit) || 10;
 
-  if (status) {
+  if (orderBy && orderBy !== "latest") {
+    status = null;
+  } else if (status) {
     status = status.toUpperCase();
   }
 
@@ -23,6 +22,7 @@ export const myChallengesApply = async (req, res, next) => {
         keyword,
         page: Number(page),
         limit: Number(limit),
+        orderBy,
       });
     } else {
       result = await getMyChallenges({
@@ -31,6 +31,7 @@ export const myChallengesApply = async (req, res, next) => {
         keyword,
         page: Number(page),
         limit: Number(limit),
+        orderBy,
       });
     }
 

--- a/repositories/myChallenge.js
+++ b/repositories/myChallenge.js
@@ -8,6 +8,7 @@ export const findMyChallenges = async ({
   keyword,
   offset,
   limit,
+  orderBy,
 }) => {
   const where = {
     ...(userId && { userId }),
@@ -23,6 +24,16 @@ export const findMyChallenges = async ({
     }),
   };
 
+  let orderQuery = { createdAt: "desc" };
+  // 기본적으로 생성일 기준 최신순
+  if (orderBy === "oldest") {
+    orderQuery = { createdAt: "asc" };
+  } else if (orderBy === "deadlineOldest") {
+    orderQuery = { dueDate: "asc" };
+  } else if (orderBy === "deadlineLatest") {
+    orderQuery = { dueDate: "desc" };
+  }
+
   return await prisma.challenge.findMany({
     where,
     include: {
@@ -34,7 +45,7 @@ export const findMyChallenges = async ({
     },
     skip: Number(offset) || 0,
     take: Number(limit) || 10,
-    orderBy: { createdAt: "desc" },
+    orderBy: orderQuery,
   });
 };
 

--- a/services/myChallenge.js
+++ b/services/myChallenge.js
@@ -9,6 +9,7 @@ export async function getMyChallenges({
   keyword,
   page = 1,
   limit = 10,
+  orderBy,
 }) {
   const offset = (page - 1) * limit;
 
@@ -19,6 +20,7 @@ export async function getMyChallenges({
     keyword: keyword || null,
     offset,
     limit,
+    orderBy,
   };
   const challenges = await findMyChallenges(filters);
 

--- a/services/translation.js
+++ b/services/translation.js
@@ -1,7 +1,4 @@
-import {
-  findTemporaryStorage,
-  createTranslation,
-} from "../repositories/translation.js";
+import { createTranslation } from "../repositories/translation.js";
 
 export async function postTranslation({
   challengeId,


### PR DESCRIPTION
이슈 번호 #4

작업 요약 : 개설한 챌린지 api를 어드민 챌린지신청관리와 같이 사용할 수 있도록 정렬 쿼리 추가

- [X] 정렬 관련 쿼리 추가