### PR TITLE
feat:개설한 챌린지 및 어드민 신청관리 백엔드 api 수정 #4

### DIFF
--- a/controllers/myChallenge.js
+++ b/controllers/myChallenge.js
@@ -12,9 +12,7 @@ export const myChallengesApply = async (req, res, next) => {
   const page = Number(req.query.page) || 1;
   const limit = Number(req.query.limit) || 10;
 
-  if (orderBy && orderBy !== "latest") {
-    status = null;
-  } else if (status) {
+  if (status) {
     status = status.toUpperCase();
   }
 
@@ -39,7 +37,7 @@ export const myChallengesApply = async (req, res, next) => {
       });
     }
 
-    res.json(result);
+    return res.status(200).json(result);
   } catch (error) {
     next(error);
   }

--- a/prisma/migrations/20250820055126_status_manage_unique/migration.sql
+++ b/prisma/migrations/20250820055126_status_manage_unique/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[challengeId]` on the table `ChallengeStatusManage` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "Translation" ADD COLUMN     "title" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ChallengeStatusManage_challengeId_key" ON "ChallengeStatusManage"("challengeId");

--- a/routes/myChallenge.js
+++ b/routes/myChallenge.js
@@ -10,4 +10,6 @@ const router = express.Router();
 router.get("/apply", authLoginMiddleware, myChallengesApply);
 router.get("/", authLoginMiddleware, getAllChallenges);
 
+router.get("/applyWidthAdmin", authLoginMiddleware, myChallengesApply);
+
 export default router;


### PR DESCRIPTION
이슈번호 #4

요약: 
개설한 챌린지 api 활용해서
개설한 챌린지 및 어드민 챌린지 신청관리 목록 조회

- [X] 개설한 챌린지 목록조회 api로 어드민 챌린지 신청관리 목록 조회